### PR TITLE
feat: Implement current admin profile retrieval and update APIs

### DIFF
--- a/src/main/java/com/example/adminService/controller/AdminProfileController.java
+++ b/src/main/java/com/example/adminService/controller/AdminProfileController.java
@@ -1,0 +1,33 @@
+package com.example.adminService.controller;
+
+import com.example.adminService.dto.request.AdminProfileUpdateDTO;
+import com.example.adminService.dto.response.AdminProfileDTO;
+import com.example.adminService.service.AdminProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/profile")
+@RequiredArgsConstructor
+public class AdminProfileController {
+    /*
+     * Controller for handling admin profile operations
+     * such as retrieving and updating the profile of the currently logged-in admin.    
+     * This controller uses the AdminProfileService to perform operations
+     * and returns the appropriate response.
+     */
+    private final AdminProfileService adminProfileService;
+
+    // Get currently logged-in admin profile
+    @GetMapping
+    public ResponseEntity<AdminProfileDTO> getProfile() {
+        return ResponseEntity.ok(adminProfileService.getCurrentAdminProfile());
+    }
+
+    // Update currently logged-in admin profile
+    @PutMapping
+    public ResponseEntity<AdminProfileDTO> updateProfile(@RequestBody AdminProfileUpdateDTO updateDTO) {
+        return ResponseEntity.ok(adminProfileService.updateCurrentAdminProfile(updateDTO));
+    }
+}

--- a/src/main/java/com/example/adminService/dto/request/AdminProfileUpdateDTO.java
+++ b/src/main/java/com/example/adminService/dto/request/AdminProfileUpdateDTO.java
@@ -1,0 +1,9 @@
+package com.example.adminService.dto.request;
+
+import lombok.Data;
+
+@Data
+public class AdminProfileUpdateDTO {
+    // Fields for updating admin profile
+    private String name;
+}

--- a/src/main/java/com/example/adminService/dto/response/AdminProfileDTO.java
+++ b/src/main/java/com/example/adminService/dto/response/AdminProfileDTO.java
@@ -1,0 +1,9 @@
+package com.example.adminService.dto.response;
+
+import lombok.Data;
+
+@Data
+public class AdminProfileDTO {
+    // Fields for admin profile response
+    private String name;
+}

--- a/src/main/java/com/example/adminService/mapper/AdminProfileMapper.java
+++ b/src/main/java/com/example/adminService/mapper/AdminProfileMapper.java
@@ -1,0 +1,17 @@
+package com.example.adminService.mapper;
+
+import com.example.adminService.dto.response.AdminProfileDTO;
+import com.example.adminService.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminProfileMapper {
+    // Converts User entity to AdminProfileDTO
+    // This method maps the User entity to the AdminProfileDTO
+
+    public AdminProfileDTO toDTO(User user) {
+        AdminProfileDTO dto = new AdminProfileDTO();
+        dto.setName(user.getName());
+        return dto;
+    }
+}

--- a/src/main/java/com/example/adminService/service/AdminProfileService.java
+++ b/src/main/java/com/example/adminService/service/AdminProfileService.java
@@ -1,0 +1,54 @@
+package com.example.adminService.service;
+
+import com.example.adminService.dto.request.AdminProfileUpdateDTO;
+import com.example.adminService.dto.response.AdminProfileDTO;
+import com.example.adminService.mapper.AdminProfileMapper;
+import com.example.adminService.model.User;
+import com.example.adminService.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminProfileService {
+    /*  
+     * Service for handling admin profile operations
+     * such as retrieving and updating the profile of the currently logged-in admin.
+     * This service interacts with the UserRepository to fetch and update user data
+     * and uses AdminProfileMapper to convert between User entity and AdminProfileDTO.
+     */
+
+    private final UserRepository userRepository;
+    private final AdminProfileMapper mapper;
+
+    // Get the currently logged-in admin's email from security context
+    private String getCurrentUserEmail() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal instanceof UserDetails) {
+            return ((UserDetails) principal).getUsername();
+        }
+        return principal.toString();
+    }
+
+    public AdminProfileDTO getCurrentAdminProfile() {
+        String email = getCurrentUserEmail();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Admin not found"));
+        return mapper.toDTO(user);
+    }
+
+    public AdminProfileDTO updateCurrentAdminProfile(AdminProfileUpdateDTO updateDTO) {
+        String email = getCurrentUserEmail();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Admin not found"));
+
+        if (updateDTO.getName() != null) {
+            user.setName(updateDTO.getName());
+        }
+
+        userRepository.save(user);
+        return mapper.toDTO(user);
+    }
+}


### PR DESCRIPTION
### **Description**

This PR adds API endpoints to retrieve and update the profile of the currently logged-in admin.

It introduces a new **`AdminProfileController`** with `GET /admin/profile` and `PUT /admin/profile` endpoints. These endpoints use **`AdminProfileService`** to fetch and update admin profile data based on the authenticated user's email from the security context.

The update no longer requires passing an admin ID, enhancing security by ensuring users can only access their own profile data.

### **List of fixes**

* Added `GET /admin/profile` endpoint to retrieve current admin profile.
* Added `PUT /admin/profile` endpoint to update current admin profile.
* Updated **`AdminProfileService`** to use the security context for retrieving the current user.
* Added **`AdminProfileMapper`** for mapping `User` entity to DTO.
* Removed ID from DTO and controller endpoints to enforce access to own profile only.


### **Type of change**

* [ ] Bug fix (non-breaking change which fixes an issue)  
* [x] New feature (non-breaking change which adds functionality)  
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
* [ ] This change requires a documentation update  


### **How has this been tested?**

* [x] Manual  
* [ ] Automation  
* [ ] Unit tested all the relevant test cases  

### **Checklist:**

* [x] My code follows the style guidelines of this project  
* [x] I have performed a self-review of my code  
* [x] I have commented my code, particularly in hard-to-understand areas  
* [ ] I have made corresponding changes to the documentation (if any)  
* [x] My changes generate no new warnings  
* [ ] I have added tests that prove my fix is effective or that my feature works  
* [x] New and existing unit tests pass locally with my changes  
* [ ] Any dependent changes have been merged and published in downstream modules  
* [x] I have linted the code locally before submission  
* [ ] I have tested responsiveness on various devices  
* [x] The code is in sync with development branch  
